### PR TITLE
Auth.go Test Case Changes

### DIFF
--- a/plugins/common/gcp/auth.go
+++ b/plugins/common/gcp/auth.go
@@ -16,6 +16,20 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+func GetToken(secret string, email string, url string) string {
+	token, err := generateJWT(secret, email, url, 120)
+
+	if err != nil {
+		println(err.Error())
+	}
+
+	accessToken, err := getGoogleID(token)
+	if err != nil {
+		println(err.Error())
+	}
+	return accessToken
+}
+
 // https://cloud.google.com/endpoints/docs/openapi/service-account-authentication#go
 func generateJWT(saKeyfile, saEmail, audience string, expiryLength int64) (string, error) {
 	now := time.Now().Unix()
@@ -46,12 +60,14 @@ func generateJWT(saKeyfile, saEmail, audience string, expiryLength int64) (strin
 	if err != nil {
 		return "", fmt.Errorf("could not read service account file: %v", err)
 	}
+
 	conf, err := google.JWTConfigFromJSON(sa)
 	if err != nil {
 		return "", fmt.Errorf("could not parse service account JSON: %v", err)
 	}
 
 	block, _ := pem.Decode(conf.PrivateKey)
+
 	parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
 		return "", fmt.Errorf("private key parse error: %v", err)
@@ -100,18 +116,4 @@ func callAPIEndpoint(method string, urls string, token string, payload io.Reader
 		return []byte{}, fmt.Errorf("error generating google id token jwt")
 	}
 	return body, nil
-}
-
-func GetToken(secret string, email string, url string) string {
-	token, err := generateJWT(secret, email, url, 120)
-
-	if err != nil {
-		println(err.Error())
-	}
-
-	accessToken, err := getGoogleID(token)
-	if err != nil {
-		println(err.Error())
-	}
-	return accessToken
 }

--- a/plugins/common/gcp/auth_test.go
+++ b/plugins/common/gcp/auth_test.go
@@ -1,65 +1,36 @@
 package gcp
 
 import (
-	"fmt"
-	"io"
-	"reflect"
+	"io/ioutil"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt"
+	"golang.org/x/oauth2/google"
 )
 
-func TestGetToken(t *testing.T) {
-	type args struct {
-		secret string
-		email  string
-		url    string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetToken(tt.args.secret, tt.args.email, tt.args.url); got != tt.want {
-				t.Errorf("GetToken() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_callAPIEndpoint(t *testing.T) {
-	type args struct {
-		method  string
-		urls    string
-		token   string
-		payload io.Reader
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := callAPIEndpoint(tt.args.method, tt.args.urls, tt.args.token, tt.args.payload)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("callAPIEndpoint() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("callAPIEndpoint() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// Testing GetToken should be the goal
+// func TestGetToken(t *testing.T) {
+// 	type args struct {
+// 		secret string
+// 		email  string
+// 		url    string
+// 	}
+// 	tests := []struct {
+// 		name string
+// 		args args
+// 		want string
+// 	}{
+// 		// TODO: Add test cases.
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := GetToken(tt.args.secret, tt.args.email, tt.args.url); got != tt.want {
+// 				t.Errorf("GetToken() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func Test_generateJWT(t *testing.T) {
 	type args struct {
@@ -78,14 +49,11 @@ func Test_generateJWT(t *testing.T) {
 		{
 			name: "Same values in claims",
 			args: args{
-				saKeyfile:    "./testdata/test_key_file.json",
-				saEmail:      "test-service-account-email@example.com",
-				audience:     "http://example.com",
-				expiryLength: time.Now().Unix() + 120,
+				saKeyfile: "./testdata/test_key_file.json",
 			},
 			want: args{
 				saEmail:      "test-service-account-email@example.com",
-				audience:     "https://www.googleapis.com/oauth2/v4/token",
+				audience:     "https://oauth2.googleapis.com/token",
 				expiryLength: time.Now().Unix() + 120,
 			},
 			wantErr: false,
@@ -93,52 +61,30 @@ func Test_generateJWT(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fmt.Println("tt.args.saKeyfile", tt.args.saKeyfile, "tt.args.saEmail", tt.args.saEmail, "tt.args.audience", tt.args.audience, "tt.args.expiryLength", tt.args.expiryLength)
-			got, err := generateJWT(tt.args.saKeyfile, tt.args.saEmail, tt.args.audience, tt.args.expiryLength)
+			// TODO: Move this configuration setup to a separate function?
+			sa, _ := ioutil.ReadFile(tt.args.saKeyfile)
+			conf, _ := google.JWTConfigFromJSON(sa)
+
+			got, err := generateJWT(tt.args.saKeyfile, conf.Audience, tt.args.expiryLength)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateJWT() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			// _, err = jwt.ParseWithClaims(h.signedJWT, &claims, func(token *jwt.Token) (interface{}, error) {
-			// 	return nil, nil
-			// })
 			claims := jwt.StandardClaims{}
 			jwt.ParseWithClaims(got, &claims, func(token *jwt.Token) (interface{}, error) {
 				return nil, nil
 			})
 
+			// TODO: What all claims do we want to check here?
 			if claims.Audience != tt.want.audience {
 				t.Errorf("generateJWT() got = %v, want %v", claims.Audience, tt.want.audience)
 			}
 			if claims.Subject != tt.want.saEmail {
 				t.Errorf("generateJWT() got = %v, want %v", claims.Subject, tt.want.saEmail)
 			}
-		})
-	}
-}
-
-func Test_getGoogleID(t *testing.T) {
-	type args struct {
-		jwtToken string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := getGoogleID(tt.args.jwtToken)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getGoogleID() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("getGoogleID() got = %v, want %v", got, tt.want)
-			}
+			// if claims.ExpiresAt != tt.want.expiryLength {
+			// 	t.Errorf("generateJWT() got = %v, want %v", claims.ExpiresAt, tt.want.expiryLength)
+			// }
 		})
 	}
 }

--- a/plugins/common/gcp/auth_test.go
+++ b/plugins/common/gcp/auth_test.go
@@ -1,90 +1,55 @@
 package gcp
 
 import (
-	"io/ioutil"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
-	"time"
-
-	"github.com/golang-jwt/jwt"
-	"golang.org/x/oauth2/google"
 )
 
-// Testing GetToken should be the goal
-// func TestGetToken(t *testing.T) {
-// 	type args struct {
-// 		secret string
-// 		email  string
-// 		url    string
-// 	}
-// 	tests := []struct {
-// 		name string
-// 		args args
-// 		want string
-// 	}{
-// 		// TODO: Add test cases.
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			if got := GetToken(tt.args.secret, tt.args.email, tt.args.url); got != tt.want {
-// 				t.Errorf("GetToken() = %v, want %v", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+func TestGetToken(t *testing.T) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"id_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijg2NzUzMDliMjJiMDFiZTU2YzIxM2M5ODU0MGFiNTYzYmZmNWE1OGMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwOi8vMTI3LjAuMC4xOjU4MDI1LyIsImF6cCI6InRlc3Qtc2VydmljZS1hY2NvdW50LWVtYWlsQGV4YW1wbGUuY29tIiwiZW1haWwiOiJ0ZXN0LXNlcnZpY2UtYWNjb3VudC1lbWFpbEBleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJleHAiOjk0NjY4NDgwMCwiaWF0Ijo5NDY2ODEyMDAsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMudGVzdC5jb20iLCJzdWIiOiIxMTAzMDAwMDk4MTM3Mzg2NzUzMDkifQ.qi2LsXP2o6nl-rbYKUlHAgTBY0QoU7Nhty5NGR4GMdc8OoGEPW-vlD0WBSaKSr11vyFcIO4ftFDWXElo9Ut-AIQPKVxinsjHIU2-LoIATgI1kyifFLyU_pBecwcI4CIXEcDK5wEkfonWFSkyDZHBeZFKbJXlQXtxj0OHvQ-DEEepXLuKY6v3s4U6GyD9_ppYUy6gzDZPYUbfPfgxCj_Jbv6qkLU0DiZ7F5-do6X6n-qkpgCRLTGHcY__rn8oe8_pSimsyJEeY49ZQ5lj4mXkVCwgL9bvL1_eW1p6sgbHaBnPKVPbM7S1_cBmzgSonm__qWyZUxfDgNdigtNsvzBQTg"}`))
+		// w.Write([]byte(`{"id_token":"abc.def"}`))
+		// w.Write([]byte(`hue`))
+	}))
+	// NewUnstartedServer creates a listener by default. Close that listener and replace with custom listener
+	fakeServer.Listener.Close()
+	l, _ := net.Listen("tcp", "localhost:58025")
+	fakeServer.Listener = l
+	fakeServer.Start()
+	defer fakeServer.Close()
 
-func Test_generateJWT(t *testing.T) {
 	type args struct {
-		saKeyfile    string
-		saEmail      string
-		audience     string
-		expiryLength int64
+		secret string
+		url    string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    args
-		wantErr bool
+		name string
+		args args
+		want string
 	}{
-		// WIP: Adding test cases.
 		{
-			name: "Same values in claims",
+			name: "test",
 			args: args{
-				saKeyfile: "./testdata/test_key_file.json",
+				secret: "./testdata/test_key_file.json",
+				url:    fakeServer.URL,
 			},
-			want: args{
-				saEmail:      "test-service-account-email@example.com",
-				audience:     "https://oauth2.googleapis.com/token",
-				expiryLength: time.Now().Unix() + 120,
-			},
-			wantErr: false,
+			want: "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijg2NzUzMDliMjJiMDFiZTU2YzIxM2M5ODU0MGFiNTYzYmZmNWE1OGMiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwOi8vMTI3LjAuMC4xOjU4MDI1LyIsImF6cCI6InRlc3Qtc2VydmljZS1hY2NvdW50LWVtYWlsQGV4YW1wbGUuY29tIiwiZW1haWwiOiJ0ZXN0LXNlcnZpY2UtYWNjb3VudC1lbWFpbEBleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJleHAiOjk0NjY4NDgwMCwiaWF0Ijo5NDY2ODEyMDAsImlzcyI6Imh0dHBzOi8vYWNjb3VudHMudGVzdC5jb20iLCJzdWIiOiIxMTAzMDAwMDk4MTM3Mzg2NzUzMDkifQ.qi2LsXP2o6nl-rbYKUlHAgTBY0QoU7Nhty5NGR4GMdc8OoGEPW-vlD0WBSaKSr11vyFcIO4ftFDWXElo9Ut-AIQPKVxinsjHIU2-LoIATgI1kyifFLyU_pBecwcI4CIXEcDK5wEkfonWFSkyDZHBeZFKbJXlQXtxj0OHvQ-DEEepXLuKY6v3s4U6GyD9_ppYUy6gzDZPYUbfPfgxCj_Jbv6qkLU0DiZ7F5-do6X6n-qkpgCRLTGHcY__rn8oe8_pSimsyJEeY49ZQ5lj4mXkVCwgL9bvL1_eW1p6sgbHaBnPKVPbM7S1_cBmzgSonm__qWyZUxfDgNdigtNsvzBQTg",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// TODO: Move this configuration setup to a separate function?
-			sa, _ := ioutil.ReadFile(tt.args.saKeyfile)
-			conf, _ := google.JWTConfigFromJSON(sa)
+			got, err := GetAccessToken(tt.args.secret, tt.args.url)
+			if err != nil {
+				fmt.Println(err)
+			}
 
-			got, err := generateJWT(tt.args.saKeyfile, conf.Audience, tt.args.expiryLength)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("generateJWT() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if got != tt.want {
+				t.Errorf("GetToken() = %v, want %v", got, tt.want)
 			}
-			claims := jwt.StandardClaims{}
-			jwt.ParseWithClaims(got, &claims, func(token *jwt.Token) (interface{}, error) {
-				return nil, nil
-			})
-
-			// TODO: What all claims do we want to check here?
-			if claims.Audience != tt.want.audience {
-				t.Errorf("generateJWT() got = %v, want %v", claims.Audience, tt.want.audience)
-			}
-			if claims.Subject != tt.want.saEmail {
-				t.Errorf("generateJWT() got = %v, want %v", claims.Subject, tt.want.saEmail)
-			}
-			// if claims.ExpiresAt != tt.want.expiryLength {
-			// 	t.Errorf("generateJWT() got = %v, want %v", claims.ExpiresAt, tt.want.expiryLength)
-			// }
 		})
 	}
 }

--- a/plugins/common/gcp/auth_test.go
+++ b/plugins/common/gcp/auth_test.go
@@ -78,13 +78,12 @@ func Test_generateJWT(t *testing.T) {
 		{
 			name: "Same values in claims",
 			args: args{
-				saKeyfile:    "./test_key_file.json",
+				saKeyfile:    "./testdata/test_key_file.json",
 				saEmail:      "test-service-account-email@example.com",
 				audience:     "http://example.com",
 				expiryLength: time.Now().Unix() + 120,
 			},
 			want: args{
-				saKeyfile:    "./test_key_file.json",
 				saEmail:      "test-service-account-email@example.com",
 				audience:     "https://www.googleapis.com/oauth2/v4/token",
 				expiryLength: time.Now().Unix() + 120,
@@ -100,11 +99,9 @@ func Test_generateJWT(t *testing.T) {
 				t.Errorf("generateJWT() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
 			// _, err = jwt.ParseWithClaims(h.signedJWT, &claims, func(token *jwt.Token) (interface{}, error) {
 			// 	return nil, nil
 			// })
-
 			claims := jwt.StandardClaims{}
 			jwt.ParseWithClaims(got, &claims, func(token *jwt.Token) (interface{}, error) {
 				return nil, nil
@@ -112,6 +109,9 @@ func Test_generateJWT(t *testing.T) {
 
 			if claims.Audience != tt.want.audience {
 				t.Errorf("generateJWT() got = %v, want %v", claims.Audience, tt.want.audience)
+			}
+			if claims.Subject != tt.want.saEmail {
+				t.Errorf("generateJWT() got = %v, want %v", claims.Subject, tt.want.saEmail)
 			}
 		})
 	}

--- a/plugins/common/gcp/testdata/test_key_file.json
+++ b/plugins/common/gcp/testdata/test_key_file.json
@@ -6,7 +6,7 @@
     "client_email": "test-service-account-email@example.com",
     "client_id": "110300009813738675309",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-    "token_uri": "https://oauth2.googleapis.com/token",
+    "token_uri": "http://localhost:58025/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service-account-email%40example.iam.gserviceaccount.com"
 }

--- a/plugins/common/gcp/testdata/test_key_file.json
+++ b/plugins/common/gcp/testdata/test_key_file.json
@@ -1,0 +1,12 @@
+{
+    "type": "service_account",
+    "project_id": "my-project",
+    "private_key_id": "223423436436453645363456",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCSHRlEzn8ONgEN\np8blw+beLbvY3iyQzTTEVuPjd39HPSJd4PiKxCqlByNNcNBATrOALB/r97/sElRK\nE0EHHrOxEyfEisPD3rwvgvWboro3REgSoVTB1IFZDoIZMOwjDbKGsrWJLANEEPb7\ngBajjONDoLWmj+U55mtM02h5ogfABO1u4u/3fAUefalLnN9FSBvBfNITKqsn0dg9\nKyXFjG6qmggUXj5zgvVrF/wITvmYflF7glqrCafTL9hft85Wzy0hvkJAjPgz4Dbx\nJAJ821B3YpWlsGQWAydjpYzA+7lMYQlHdaDAvnOum2UV2+EAlnk93Htdt1QRGkTo\nhAocDbMZAgMBAAECggEAPk1DD4g/O+eCFnkCQcmBAR6eGPBPL2UYiVmFbWHwNweV\nxlLdl4nipyB+iJBAdBM6zb3C1MJ8puP/5eAE28zXEPuaet8ybyvjsRyVrom5/kPS\nuYLqGYYLq1YY2jX2klHOXEoKRxWpxNW5Am9Q9+bkptr5aa60rrYV7Zm9VBPnWxP5\ny2gj6qQ+4WrDILUfMxYm0Wr7f9cvoNQATcZVoIhu09Mf23sVn/iAh1R2A6ky2MOQ\nIrqdMdKiur+C0mfKRfqTQpcnG9DaInnsETQ4AdDUu2TlvQWBKhCaLCWVvWITDusE\nmnc1+hZy30TSk8iIpzbt8XOm0jPn/guYcrB+EtwVOwKBgQDG/hK/Wi0Krods0ytj\ntYfvx87L+AvhGgl9HqKJkRdyA1tJPybZKqOsnchUxk1DSpj0V3X6YETC3nUjVixW\n//ouyvV1GZGXuOYS/YaD1I3EdrMZ7ZTCi+xrpbUwjI6fH4oJ/J4aTfOz7Bve7/Mt\nRZgckmgnpRSWzzDF6NANujwgfwKBgQC7+PEjnMe/a6xWpfr8W+Him9KKWMkz6MQw\n6EkQ0RK6JrBi3CIsVa7G3RrWQd81A+TjbMVRxb5aWKahUtPKboTqNfKQixSD4U9J\nfzQdGM06ZPAYProRru/Bcm1H4/nQ5EUogzKU5a0nnutn0c9ScoUiAPGylucbLTic\nVZoUp9NgZwKBgBOJKgoDLlzYGY+Dg8T8M2ZE9XZs2a21wqy37zkWN3kH/1RHkObN\nGth9fQdlmHw8vJtwYrK79MQ01scrVJsN8l/ZqRNf+T0t99hxb11N5sUc6iRngK1A\n02sWD52+jtnsXL7yQAtRD9XgHjRa1kLhjDdx4CvUNxs/KAil/Jb8a569AoGALRxh\nQpqtlVLR2TmcMlQasbeTn4APSVXjP5l/b3m9dM80JYWO7fTiLPeDKUhFuQNmOu4v\nrKA4PpZn5u9pxHshitPHksjN85hu3sSYTSNWnVz8AdWL8hJ5l4NOlqIvoeImdsKF\nsRYtqASLmi7QAolZSf/QAXwVmoAPxfUFNU/ReqECgYEAqW+adsTx1F9WCMLdj27D\ny/75+kF0WQI/76LOvtliiHCNjGksBjHrbnuNma2AKRo5nax3Qxs0rHetf991Ii13\nbbEHZhPhRu/jJrrPdHrOlI0x9ChAvuUMhs1Kp/M/bA0EoQF4uSg2bN5vDAc/GeVH\n1xhjjq1VcGPKgxwV7RhyI+s=\n-----END PRIVATE KEY-----\n",
+    "client_email": "test-service-account-email@example.com",
+    "client_id": "110300009813738675309",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-service-account-email%40example.iam.gserviceaccount.com"
+}

--- a/plugins/outputs/cloudrun/README.md
+++ b/plugins/outputs/cloudrun/README.md
@@ -11,6 +11,7 @@ CloudRun Conf file syntax:
   ## Timeout for HTTP message
   timeout = "30s"
 
+  <!-- TODO: Strike cloudrun_email -->
   cloudrun_email = "svc-acct-proxy@domain.iam.gserviceaccount.com"
   json_file_location = "C:/Path/To/Secrets/file.json"
   data_format = "wavefront"

--- a/plugins/outputs/cloudrun/cloudrun.go
+++ b/plugins/outputs/cloudrun/cloudrun.go
@@ -157,7 +157,10 @@ func (h *CloudRun) write(reqBody []byte) error {
 	})
 
 	if h.accessToken == "" || !claims.VerifyExpiresAt(time.Now().Unix(), true) {
-		h.accessToken = gcp.GetAccessToken(h.JSONSecret, h.URL)
+		h.accessToken, err = gcp.GetAccessToken(h.JSONSecret, h.URL)
+		if err != nil {
+			return err
+		}
 	}
 
 	bearerToken := fmt.Sprintf("Bearer %s", h.accessToken)


### PR DESCRIPTION
- refactored auth.go to no longer use hardcoded values
- instead pulling previously hardcoded values from secret.json, simplifying telegraf.conf Cloud Run section
- aligned variable names with oauth2 terminology
- updated README